### PR TITLE
fix(readme): broken な github-readme-stats カードを一時的にコメントアウト

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,15 @@ My name is Koji Kawazu — 🔧 Backend Engineer | 🐧 Linux Engineer
 
 ### Status
 
+<!--
+github-readme-stats.vercel.app is currently DEPLOYMENT_PAUSED (HTTP 503).
+Hidden until upstream recovers, or migrate to self-hosted Vercel instance.
+
 <div>
   <a href="https://github.com/anuraghazra/github-readme-stats"><img alt="Top Langs" height="150px" src="https://github-readme-stats.vercel.app/api/top-langs/?username=kojikawazu&theme=transparent" /></a>
   <a href="https://github.com/anuraghazra/github-readme-stats"><img alt="github stats" height="150px" src="https://github-readme-stats.vercel.app/api?username=kojikawazu&show_icons=true&theme=transparent" /></a>
 </div>
+-->
 
 [![trophy](https://github-profile-trophy.vercel.app/?username=kojikawazu&theme=onedark&column=7)](https://github.com/ryo-ma/github-profile-trophy)
 


### PR DESCRIPTION
## Summary
- `github-readme-stats.vercel.app` の上流デプロイメントが `DEPLOYMENT_PAUSED` 状態 (HTTP 503) のため、Top Langs / github stats の 2 カードが broken image として表示されていた問題を一時退避
- 該当の `<div>` ブロックを HTML コメント `<!-- ... -->` で囲んで非表示化（GitHub Markdown レンダラで完全に非表示）
- 元コードはコメント内に保持し、上流復旧時に `<!-- -->` を外すだけで戻せるようにした
- コメント内に状況説明と将来の対応方針（自前 Vercel への移行）を TODO として記載

## 検証ログ
```
$ curl -sI 'https://github-readme-stats.vercel.app/api/top-langs/?username=kojikawazu&theme=transparent'
HTTP/2 503
x-vercel-error: DEPLOYMENT_PAUSED
```

## Test plan
- [ ] GitHub プロフィールページで Status セクションが broken image なしで表示されること
- [ ] トロフィー行（`github-profile-trophy.vercel.app`）が引き続き正常表示されること
- [ ] README ソース閲覧時に、コメント内の状況説明が読めること

## 中長期 TODO（このPRのスコープ外）
- [ ] 自前 Vercel に github-readme-stats を deploy し、URL を独自インスタンスに切り替え

🤖 Generated with [Claude Code](https://claude.com/claude-code)